### PR TITLE
fix: change the ToposCore admin to subnet validator

### DIFF
--- a/scripts/deploy-topos-msg-protocol-dynamic.ts
+++ b/scripts/deploy-topos-msg-protocol-dynamic.ts
@@ -74,9 +74,10 @@ const main = async function (...args: string[]) {
   console.log(`Topos Core contract deployed to ${ToposCore.address}`)
 
   // Deploy ToposCoreProxy
+  const sequencerEthAddress = utils.computeAddress(sequencerPrivateKey)
   const toposCoreProxyParams = utils.defaultAbiCoder.encode(
     ['address[]', 'uint256'],
-    [[wallet.address], 1] // TODO: Use a different admin address than ToposDeployer
+    [[sequencerEthAddress], 1]
   )
   const ToposCoreProxyFactory = new ContractFactory(
     toposCoreProxyJSON.abi,
@@ -106,10 +107,11 @@ const main = async function (...args: string[]) {
   console.log(`ERC20 Messaging contract deployed to ${ERC20Messaging.address}`)
 
   console.info(`\nSetting subnetId on ToposCore via proxy`)
+  const sequencerWallet = new Wallet(sequencerPrivateKey, provider)
   const toposCoreInterface = new Contract(
     ToposCoreProxy.address,
     toposCoreInterfaceJSON.abi,
-    wallet
+    sequencerWallet
   )
   await toposCoreInterface
     .setNetworkSubnetId(subnetId, { gasLimit: 4_000_000 })

--- a/scripts/deploy-topos-msg-protocol.ts
+++ b/scripts/deploy-topos-msg-protocol.ts
@@ -73,9 +73,10 @@ const main = async function (...args: string[]) {
     4_000_000
   )
 
+  const sequencerEthAddress = utils.computeAddress(sequencerPrivateKey)
   const toposCoreProxyParams = utils.defaultAbiCoder.encode(
     ['address[]', 'uint256'],
-    [[wallet.address], 1] // TODO: Use a different admin address than ToposDeployer
+    [[sequencerEthAddress], 1]
   )
   const toposCoreProxyAddress = await processContract(
     wallet,
@@ -93,7 +94,8 @@ const main = async function (...args: string[]) {
     4_000_000
   )
 
-  setSubnetId(toposCoreProxyAddress, wallet, subnetId)
+  const sequencerWallet = new Wallet(sequencerPrivateKey, provider)
+  setSubnetId(toposCoreProxyAddress, sequencerWallet, subnetId)
 
   console.log(`
 export TOPOS_CORE_CONTRACT_ADDRESS=${toposCoreAddress}


### PR DESCRIPTION
# Description

This PR modifies the topos messaging protocol deployment script to change the admin of the `ToposCore` contract from the static deployer to the subnet validator.

## Additions and Changes

- Added logic to transfer some funds from the deployer account to the sequencer account
- Changed the `toposCoreProxyParams` to the validator key in `deploy-topos-msg-protocol.ts` script
- Changed the `toposCoreProxyParams` to the validator key in `deploy-topos-msg-protocol-dynamic.ts` script
- Changed deployer's wallet to sequencer's wallet when setting up the `subnetId` as the sequencer would now be the owner of the `ToposCore` contract

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
