### PR TITLE
fix: return value of a storage cert

### DIFF
--- a/contracts/interfaces/IToposCore.sol
+++ b/contracts/interfaces/IToposCore.sol
@@ -57,23 +57,7 @@ interface IToposCore {
 
     function getCertIdAtIndex(uint256 index) external view returns (CertificateId);
 
-    function getCertificate(
-        CertificateId certId
-    )
-        external
-        view
-        returns (
-            CertificateId,
-            SubnetId,
-            bytes32,
-            bytes32,
-            SubnetId[] memory,
-            uint32,
-            CertificateId,
-            bytes memory,
-            bytes memory,
-            uint256
-        );
+    function getCertificate(CertificateId certId) external view returns (Certificate memory storedCert);
 
     function getCertificateCount() external view returns (uint256);
 

--- a/contracts/topos-core/ToposCore.sol
+++ b/contracts/topos-core/ToposCore.sol
@@ -177,36 +177,8 @@ contract ToposCore is IToposCore, AdminMultisigBase, Initializable {
 
     /// @notice Get the certificate for the provided certificate ID
     /// @param certId certificate ID
-    function getCertificate(
-        CertificateId certId
-    )
-        public
-        view
-        returns (
-            CertificateId,
-            SubnetId,
-            bytes32,
-            bytes32,
-            SubnetId[] memory,
-            uint32,
-            CertificateId,
-            bytes memory,
-            bytes memory,
-            uint256
-        )
-    {
-        Certificate memory storedCert = certificates[certId];
-        (
-            storedCert.prevId,
-            storedCert.sourceSubnetId,
-            storedCert.stateRoot,
-            storedCert.receiptRoot,
-            storedCert.targetSubnets,
-            storedCert.verifier,
-            storedCert.certId,
-            storedCert.starkProof,
-            storedCert.signature
-        );
+    function getCertificate(CertificateId certId) public view returns (Certificate memory storedCert) {
+        storedCert = certificates[certId];
     }
 
     /// @notice Get the checkpoints for the received source subnet IDs

--- a/test/topos-core/ToposCore.test.ts
+++ b/test/topos-core/ToposCore.test.ts
@@ -228,6 +228,27 @@ describe('ToposCore', () => {
       )
     })
 
+    it('gets a storage certificate', async () => {
+      const { defaultCert, toposCore } = await loadFixture(
+        deployToposCoreFixture
+      )
+      await toposCore.pushCertificate(defaultCert, cc.CERT_POS_1)
+      const certificate = await toposCore.getCertificate(cc.CERT_ID_1)
+      const encodedCert = testUtils.encodeCertParam(
+        certificate.prevId,
+        certificate.sourceSubnetId,
+        certificate.stateRoot,
+        certificate.txRoot,
+        certificate.receiptRoot,
+        certificate.targetSubnets,
+        certificate.verifier,
+        certificate.certId,
+        certificate.starkProof,
+        certificate.signature
+      )
+      expect(encodedCert).to.equal(defaultCert)
+    })
+
     it('emits a certificate stored event', async () => {
       const { defaultCert, toposCore } = await loadFixture(
         deployToposCoreFixture


### PR DESCRIPTION
# Description

This PR resolves the issue of retrieving the return value from a certificate that is stored within the `ToposCore` contract.

Fixes TP-607

## Additions and Changes

- Changed the return value of the `getCertificate` method in `ToposCore` contract

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
