### PR TITLE
feat: add initialize func to SubnerRegistrator

### DIFF
--- a/contracts/topos-core/SubnetRegistrator.sol
+++ b/contracts/topos-core/SubnetRegistrator.sol
@@ -30,6 +30,10 @@ contract SubnetRegistrator is Ownable {
     /// @notice Subnet removal event
     event SubnetRemoved(SubnetId subnetId);
 
+    constructor(address admin) Ownable() {
+        _transferOwnership(admin);
+    }
+
     /// @notice Check if the subnet is already registered
     /// @param subnetId FROST public key of a subnet
     function subnetExists(SubnetId subnetId) external view returns (bool) {

--- a/contracts/topos-core/SubnetRegistrator.sol
+++ b/contracts/topos-core/SubnetRegistrator.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.9;
 
 import "./Bytes32Sets.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 type SubnetId is bytes32;
 
-contract SubnetRegistrator is Ownable {
+contract SubnetRegistrator is Initializable, Ownable {
     using Bytes32SetsLib for Bytes32SetsLib.Set;
 
     struct Subnet {
@@ -30,10 +31,6 @@ contract SubnetRegistrator is Ownable {
     /// @notice Subnet removal event
     event SubnetRemoved(SubnetId subnetId);
 
-    constructor(address admin) Ownable() {
-        _transferOwnership(admin);
-    }
-
     /// @notice Check if the subnet is already registered
     /// @param subnetId FROST public key of a subnet
     function subnetExists(SubnetId subnetId) external view returns (bool) {
@@ -49,6 +46,13 @@ contract SubnetRegistrator is Ownable {
     /// @param index index at which the Subnet ID is stored
     function getSubnetIdAtIndex(uint256 index) external view returns (SubnetId) {
         return SubnetId.wrap(subnetSet.keyAtIndex(index));
+    }
+
+    /// @notice Contract initializer
+    /// @dev Can only be called once
+    /// @param admin address of the admin
+    function initialize(address admin) public initializer {
+        _transferOwnership(admin);
     }
 
     /// @notice Register a new subnet

--- a/scripts/deploy-subnet-registrator.ts
+++ b/scripts/deploy-subnet-registrator.ts
@@ -1,0 +1,33 @@
+import { providers, utils, Wallet } from 'ethers'
+import subnetRegistratorJSON from '../artifacts/contracts/topos-core/SubnetRegistrator.sol/SubnetRegistrator.json'
+import { Arg, deployContractConstant } from './const-addr-deployer'
+
+const main = async function (..._args: Arg[]) {
+  const [providerEndpoint, privateKey, salt, gasLimit, ...args] = _args
+  const provider = new providers.JsonRpcProvider(<string>providerEndpoint)
+
+  const sequencerPrivateKey = sanitizeHexString(<string>privateKey || '')
+  if (!utils.isHexString(sequencerPrivateKey, 32)) {
+    console.error('ERROR: Please provide a valid private key!')
+    return
+  }
+
+  const wallet = new Wallet(sequencerPrivateKey || '', provider)
+  const address = await deployContractConstant(
+    wallet,
+    subnetRegistratorJSON,
+    <string>salt,
+    [wallet.address, ...args],
+    <number>gasLimit
+  )
+    .then(({ address }) => address)
+    .catch(console.error)
+  console.log(address)
+}
+
+const sanitizeHexString = function (hexString: string) {
+  return hexString.startsWith('0x') ? hexString : `0x${hexString}`
+}
+
+const args = process.argv.slice(2)
+main(...args)

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,5 +1,4 @@
-/* eslint-disable no-case-declarations */
-import { ContractFactory, providers, utils, Wallet } from 'ethers'
+import { providers, utils, Wallet } from 'ethers'
 import fs from 'fs'
 
 import {
@@ -9,14 +8,7 @@ import {
 } from './const-addr-deployer'
 
 const main = async function (..._args: Arg[]) {
-  const [
-    providerEndpoint,
-    contractJsonPath,
-    salt,
-    gasLimit,
-    deployConstant,
-    ...args
-  ] = _args
+  const [providerEndpoint, contractJsonPath, salt, gasLimit, ...args] = _args
   const provider = new providers.JsonRpcProvider(<string>providerEndpoint)
   const privateKey = process.env.PRIVATE_KEY
 
@@ -47,37 +39,17 @@ const main = async function (..._args: Arg[]) {
     return
   }
 
-  switch (deployConstant) {
-    case 'true':
-      const address = await deployContractConstant(
-        wallet,
-        contractJson,
-        <string>salt,
-        args,
-        <number>gasLimit
-      )
-        .then(({ address }) => address)
-        .catch(console.error)
+  const address = await deployContractConstant(
+    wallet,
+    contractJson,
+    <string>salt,
+    args,
+    <number>gasLimit
+  )
+    .then(({ address }) => address)
+    .catch(console.error)
 
-      console.log(address)
-      break
-    case 'false':
-      const contractFactory = new ContractFactory(
-        contractJson.abi,
-        contractJson.bytecode,
-        wallet
-      )
-      const contract = await contractFactory.deploy(...args, {
-        gasLimit: BigInt(gasLimit),
-      })
-      await contract.deployed()
-      console.log(contract.address)
-      break
-    default:
-      console.error(
-        `ERROR: Please provide a valid deployConstant flag! (true|false)`
-      )
-  }
+  console.log(address)
 }
 
 const args = process.argv.slice(2)

--- a/scripts/register-subnet.ts
+++ b/scripts/register-subnet.ts
@@ -77,7 +77,7 @@ const main = async function (...args: string[]) {
     process.exit(1)
   }
 
-  const wallet = new Wallet(toposDeployerPrivateKey, provider)
+  const wallet = new Wallet(sequencerPrivateKey, provider)
 
   const contract = new Contract(
     subnetRegistratorAddress,

--- a/test/topos-core/SubnetRegistrator.test.ts
+++ b/test/topos-core/SubnetRegistrator.test.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 describe('SubnetRegistrator', () => {
   let subnetRegistrator: Contract
 
+  const admin = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
   const endpoint = 'http://127.0.0.1'
   const logoURL = 'http://image-url.com'
   const subnetName = 'Test Subnet'
@@ -16,7 +17,7 @@ describe('SubnetRegistrator', () => {
     const SubnetRegistrator = await ethers.getContractFactory(
       'SubnetRegistrator'
     )
-    subnetRegistrator = await SubnetRegistrator.deploy()
+    subnetRegistrator = await SubnetRegistrator.deploy(admin)
   })
 
   describe('registerSubnet', () => {


### PR DESCRIPTION
# Description

This PR adds an admin parameter for the `SubnetRegistrator.sol` smart contract via an initialize function.
The rationale is to have a constant address for the `SubnetRegistrator.sol` smart contract while having access control.

Fixes TP-700

## Additions and Changes

- Revert changes in the `deploy.ts` scripts introduced in #102
- Added a parameter `admin` in the `initialize` func of the `SubnerRegistrator.sol` smart contract
- Added `deploy-subnet-registrator.ts` script
- Made changes to the `register-subnet.ts` script to allow the sequencer/validator to register a subnet

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
