### PR TITLE
fix: set gas limit in register subnet script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-protocol/topos-smart-contracts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Topos Smart Contracts",
   "repository": {
     "type": "git",

--- a/scripts/register-subnet.ts
+++ b/scripts/register-subnet.ts
@@ -102,7 +102,8 @@ const main = async function (...args: string[]) {
     subnetName,
     subnetId,
     subnetCurrencySymbol,
-    subnetChainId
+    subnetChainId,
+    { gasLimit: 4_000_000 }
   )
 
   await tx


### PR DESCRIPTION
# Description

This PR adds an explicit gas limit in the register-subnet script to fix a gas estimation tx error.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
