### PR TITLE
fix: use right admin priv key for register subnet script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-protocol/topos-smart-contracts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Topos Smart Contracts",
   "repository": {
     "type": "git",

--- a/scripts/deploy-subnet-registrator.ts
+++ b/scripts/deploy-subnet-registrator.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractFactory, providers, utils, Wallet } from 'ethers'
+import { Contract, providers, utils, Wallet } from 'ethers'
 
 import subnetRegistratorJSON from '../artifacts/contracts/topos-core/SubnetRegistrator.sol/SubnetRegistrator.json'
 import { Arg, deployContractConstant } from './const-addr-deployer'

--- a/scripts/register-subnet.ts
+++ b/scripts/register-subnet.ts
@@ -55,7 +55,7 @@ const main = async function (...args: string[]) {
 
   const adminPrivateKey = sanitizeHexString(_adminPrivateKey)
 
-  if (!utils.isHexString(_adminPrivateKey, 32)) {
+  if (!utils.isHexString(adminPrivateKey, 32)) {
     console.error('ERROR: The admin private key is not a valid key!')
     process.exit(1)
   }

--- a/scripts/register-subnet.ts
+++ b/scripts/register-subnet.ts
@@ -11,16 +11,14 @@ const main = async function (...args: string[]) {
     subnetRPCEndpoint,
     subnetCurrencySymbol,
     subnetLogoUrl,
+    _adminPrivateKey,
     _sequencerPrivateKey,
   ] = args
   const provider = new providers.JsonRpcProvider(toposSubnetProviderEndpoint)
-  const toposDeployerPrivateKey = sanitizeHexString(
-    process.env.PRIVATE_KEY || ''
-  )
 
-  if (!utils.isHexString(toposDeployerPrivateKey, 32)) {
+  if (!_adminPrivateKey) {
     console.error(
-      'ERROR: Please provide a valid toposDeployer private key! (PRIVATE_KEY)'
+      'ERROR: Please provide the SubnetRegistrator admin private key!'
     )
     process.exit(1)
   }
@@ -55,6 +53,13 @@ const main = async function (...args: string[]) {
     process.exit(1)
   }
 
+  const adminPrivateKey = sanitizeHexString(_adminPrivateKey)
+
+  if (!utils.isHexString(_adminPrivateKey, 32)) {
+    console.error('ERROR: The admin private key is not a valid key!')
+    process.exit(1)
+  }
+
   const sequencerPrivateKey = sanitizeHexString(_sequencerPrivateKey)
 
   if (!utils.isHexString(sequencerPrivateKey, 32)) {
@@ -77,7 +82,7 @@ const main = async function (...args: string[]) {
     process.exit(1)
   }
 
-  const wallet = new Wallet(sequencerPrivateKey, provider)
+  const wallet = new Wallet(adminPrivateKey, provider)
 
   const contract = new Contract(
     subnetRegistratorAddress,


### PR DESCRIPTION
# Description

This PR fixes the issue introduced by #107 where a single private key is used both for creating the admin wallet capable of register a new subnet and the new subnet id. To fix this, we introduce a new arg to pass an `adminPrivateKey` separately from the `sequencerPrivateKey`.

[Passing e2e-tests workflow run](https://github.com/topos-protocol/e2e-tests/actions/runs/6165023442)

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
