### PR TITLE
chore: remove check for existing tokens

### DIFF
--- a/scripts/test/send-token.ts
+++ b/scripts/test/send-token.ts
@@ -1,4 +1,4 @@
-import { Contract, providers, utils, Wallet, constants } from 'ethers'
+import { Contract, providers, utils, Wallet } from 'ethers'
 import { keccak256 } from '@ethersproject/keccak256'
 import { toUtf8Bytes } from '@ethersproject/strings'
 
@@ -59,7 +59,6 @@ const main = async function (...args: string[]) {
     tc.TOKEN_NAME,
     tc.TOKEN_SYMBOL_X,
     tc.MINT_CAP_100_000_000,
-    constants.AddressZero,
     tc.DAILY_MINT_LIMIT_100,
     tc.INITIAL_SUPPLY_10_000_000
   )

--- a/test/topos-core/ToposMessaging.test.ts
+++ b/test/topos-core/ToposMessaging.test.ts
@@ -42,7 +42,6 @@ describe('ToposMessaging', () => {
       tc.TOKEN_NAME,
       tc.TOKEN_SYMBOL_X,
       tc.MINT_CAP_100_000_000,
-      ethers.constants.AddressZero,
       tc.DAILY_MINT_LIMIT_100,
       tc.INITIAL_SUPPLY_10_000_000
     )
@@ -116,7 +115,6 @@ describe('ToposMessaging', () => {
         tc.TOKEN_NAME,
         tc.TOKEN_SYMBOL_Y,
         tc.MINT_CAP_100_000_000,
-        ethers.constants.AddressZero,
         tc.DAILY_MINT_LIMIT_100,
         tc.INITIAL_SUPPLY_10_000_000
       )
@@ -151,38 +149,10 @@ describe('ToposMessaging', () => {
       const { defaultToken, erc20Messaging } = await loadFixture(
         deployERC20MessagingFixture
       )
-      const tx = await erc20Messaging.deployToken(defaultToken)
-      const txReceipt = await tx.wait()
-      const logs = txReceipt.events?.find((e) => e.event === 'TokenDeployed')
-      const tokenAddress = logs?.args?.tokenAddress
-      const token = testUtils.encodeTokenParam(
-        tc.TOKEN_NAME,
-        tc.TOKEN_SYMBOL_X,
-        tc.MINT_CAP_100_000_000,
-        tokenAddress,
-        tc.DAILY_MINT_LIMIT_100,
-        tc.INITIAL_SUPPLY_10_000_000
-      )
+      await erc20Messaging.deployToken(defaultToken)
       await expect(
-        erc20Messaging.deployToken(token)
-      ).to.be.revertedWithCustomError(erc20Messaging, 'TokenAlreadyExists')
-    })
-
-    it('reverts if the token is an external token', async () => {
-      const [extToken] = await ethers.getSigners()
-      const { erc20Messaging } = await loadFixture(deployERC20MessagingFixture)
-      const token = testUtils.encodeTokenParam(
-        tc.TOKEN_NAME,
-        tc.TOKEN_SYMBOL_X,
-        tc.MINT_CAP_100_000_000,
-        extToken.address,
-        tc.DAILY_MINT_LIMIT_100,
-        tc.INITIAL_SUPPLY_10_000_000
-      )
-      await expect(
-        erc20Messaging.deployToken(token)
-      ).to.be.revertedWithCustomError(erc20Messaging, 'UnsupportedTokenType')
-      expect(await erc20Messaging.getTokenCount()).to.equal(0)
+        erc20Messaging.deployToken(erc20Messaging.deployToken(defaultToken))
+      ).to.be.reverted
     })
 
     it('allows two separate deployers to deploy tokens with same symbol', async () => {
@@ -231,7 +201,6 @@ describe('ToposMessaging', () => {
         tc.TOKEN_NAME,
         tc.TOKEN_SYMBOL_X,
         tc.MINT_CAP_100_000_000,
-        ethers.constants.AddressZero,
         0,
         tc.INITIAL_SUPPLY_10_000_000
       )

--- a/test/topos-core/shared/utils/common.ts
+++ b/test/topos-core/shared/utils/common.ts
@@ -44,13 +44,12 @@ function encodeTokenParam(
   tokenName: string,
   tokenSymbol: string,
   mintCap: number,
-  address: string,
   dailyMintLimit: number,
   initialSupply: number
 ) {
   return ethers.utils.defaultAbiCoder.encode(
-    ['string', 'string', 'uint256', 'address', 'uint256', 'uint256'],
-    [tokenName, tokenSymbol, mintCap, address, dailyMintLimit, initialSupply]
+    ['string', 'string', 'uint256', 'uint256', 'uint256'],
+    [tokenName, tokenSymbol, mintCap, dailyMintLimit, initialSupply]
   )
 }
 


### PR DESCRIPTION
# Description

This PR removes the check for `External` ERC20 token addresses when deploying an ERC20 token via the Topos Cross-Subnet Messaging Protocol.
Only `Internal` tokens are allowed to be deployed.

Fixes TP-782

## Additions and Changes

- Removed the address param from the input `params` for the `sendToken` method in `ERC20Messaging.sol` smart contract
- Adapted the unit tests to the changes

# Breaking Changes

Changes the input `params` for the `deployToken` function so will require changes to the infra as well

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
