### PR TITLE
chore: bump package-lock.json version to v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@topos-protocol/topos-smart-contracts",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@topos-protocol/topos-smart-contracts",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.3",


### PR DESCRIPTION
# Description

Bumps the `package-lock.json` ver to match the `package.lock` ver

`v3.0.0` -> `v3.1.0`

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
