### PR TITLE
feat: add unique receipts for cross-subnet transactions

### DIFF
--- a/contracts/interfaces/IToposCore.sol
+++ b/contracts/interfaces/IToposCore.sol
@@ -25,7 +25,7 @@ interface IToposCore {
 
     event CertStored(CertificateId certId, bytes32 receiptRoot);
 
-    event CrossSubnetMessageSent(SubnetId indexed targetSubnetId);
+    event CrossSubnetMessageSent(SubnetId indexed targetSubnetId, SubnetId sourceSubnetId, uint256 nonce);
 
     event Upgraded(address indexed implementation);
 

--- a/contracts/interfaces/IToposMessaging.sol
+++ b/contracts/interfaces/IToposMessaging.sol
@@ -27,7 +27,7 @@ interface IToposMessaging {
     function validateMerkleProof(
         bytes memory proofBlob,
         bytes32 receiptRoot
-    ) external returns (bytes memory receiptRaw);
+    ) external returns (bytes memory receiptTrieNodeRaw);
 
     function toposCore() external view returns (address);
 }

--- a/contracts/topos-core/CodeHash.sol
+++ b/contracts/topos-core/CodeHash.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.9;
 contract CodeHash {
     /// @notice gets the codehash of a contract address
     /// @param contractAddr a contract address
-    function getCodeHash(address contractAddr) public view returns (bytes32) {
+    function getCodeHash(address contractAddr) public view returns (bytes32 codeHash) {
         // does not fail with wallet addresses
         if (contractAddr.codehash.length != 0) {
-            return contractAddr.codehash;
+            codeHash =  contractAddr.codehash;
         }
     }
 }

--- a/contracts/topos-core/CodeHash.sol
+++ b/contracts/topos-core/CodeHash.sol
@@ -7,7 +7,7 @@ contract CodeHash {
     function getCodeHash(address contractAddr) public view returns (bytes32 codeHash) {
         // does not fail with wallet addresses
         if (contractAddr.codehash.length != 0) {
-            codeHash =  contractAddr.codehash;
+            codeHash = contractAddr.codehash;
         }
     }
 }

--- a/contracts/topos-core/ToposCore.sol
+++ b/contracts/topos-core/ToposCore.sol
@@ -18,6 +18,10 @@ contract ToposCore is IToposCore, AdminMultisigBase, Initializable {
     /// @notice The subnet ID of the subnet this contract is to be deployed on
     SubnetId public networkSubnetId;
 
+    /// @notice Nonce for cross subnet message, meant to be used in combination with `sourceSubnetId`
+    /// so that the message can be uniquely identified per subnet
+    uint256 private nonce;
+
     /// @notice Set of certificate IDs
     Bytes32SetsLib.Set certificateSet;
 
@@ -113,7 +117,8 @@ contract ToposCore is IToposCore, AdminMultisigBase, Initializable {
     /// @notice Emits an event to signal a cross subnet message has been sent
     /// @param targetSubnetId The subnet ID of the target subnet
     function emitCrossSubnetMessage(SubnetId targetSubnetId) external {
-        emit CrossSubnetMessageSent(targetSubnetId);
+        nonce += 1;
+        emit CrossSubnetMessageSent(targetSubnetId, networkSubnetId, nonce);
     }
 
     /// @notice Returns the admin epoch

--- a/test/topos-core/ToposMessaging.test.ts
+++ b/test/topos-core/ToposMessaging.test.ts
@@ -82,10 +82,7 @@ describe('ToposMessaging', () => {
     await toposCoreProxy.waitForDeployment()
     const toposCoreProxyAddress = await toposCoreProxy.getAddress()
 
-    const toposCore = await ToposCore__factory.connect(
-      toposCoreProxyAddress,
-      admin
-    )
+    const toposCore = ToposCore__factory.connect(toposCoreProxyAddress, admin)
     await toposCore.initialize(adminAddresses, adminThreshold)
 
     const erc20Messaging = await new ERC20Messaging__factory(admin).deploy(
@@ -214,7 +211,7 @@ describe('ToposMessaging', () => {
         (l) => (l as EventLog).eventName === 'TokenDeployed'
       ) as EventLog
       const tokenAddress = log.args.tokenAddress
-      const erc20 = await ERC20__factory.connect(tokenAddress, admin)
+      const erc20 = ERC20__factory.connect(tokenAddress, admin)
       await erc20.approve(erc20MessagingAddress, tc.SEND_AMOUNT_50)
 
       const sendToken = await sendTokenTx(
@@ -499,7 +496,7 @@ describe('ToposMessaging', () => {
       const deployedToken = await erc20Messaging.getTokenBySymbol(
         tc.TOKEN_SYMBOL_X
       )
-      const erc20 = await ERC20__factory.connect(deployedToken.addr, admin)
+      const erc20 = ERC20__factory.connect(deployedToken.addr, admin)
       await erc20.approve(erc20MessagingAddress, tc.SEND_AMOUNT_50)
 
       const sendToken = await sendTokenTx(
@@ -549,7 +546,7 @@ describe('ToposMessaging', () => {
       const deployedToken = await erc20Messaging.getTokenBySymbol(
         tc.TOKEN_SYMBOL_X
       )
-      const erc20 = await ERC20__factory.connect(deployedToken.addr, admin)
+      const erc20 = ERC20__factory.connect(deployedToken.addr, admin)
       await erc20.approve(erc20MessagingAddress, tc.SEND_AMOUNT_50)
 
       const sendToken = await sendTokenTx(
@@ -757,7 +754,7 @@ describe('ToposMessaging', () => {
         (l) => (l as EventLog).eventName === 'TokenDeployed'
       ) as EventLog
       const tokenAddress = log.args.tokenAddress
-      const erc20 = await ERC20__factory.connect(tokenAddress, admin)
+      const erc20 = ERC20__factory.connect(tokenAddress, admin)
       await erc20.approve(erc20MessagingAddress, tc.SEND_AMOUNT_50)
 
       await expect(
@@ -796,7 +793,7 @@ describe('ToposMessaging', () => {
       (l) => (l as EventLog).eventName === 'TokenDeployed'
     ) as EventLog
     const tokenAddress = log.args.tokenAddress
-    const erc20 = await ERC20__factory.connect(tokenAddress, admin)
+    const erc20 = ERC20__factory.connect(tokenAddress, admin)
     await erc20.approve(erc20MessagingAddress, tc.SEND_AMOUNT_50)
 
     const receiverAddress = await receiver.getAddress()


### PR DESCRIPTION
# Description

This PR resolves the issue with the `receiptHash` not being unique for two or more cross-subnet transactions.

## Problem

Let's try to understand the issue with the following example. For two identical `sendToken` transactions from the same user on the same subnet, i.e. two transactions where the allowance amount and the arguments for the `sendToken` transaction are kept the same, we would end up in a situation where the `receiptHash` would also be identical for these two transactions. This is because there is no nonce for receipts as opposed to transactions where a combination of `from` and `nonce` is kept track of to prevent replay attacks. If the two transactions end up in different blocks (let's assume there are no other transactions in both blocks), then the `receiptsRoot` for both blocks would also be identical.

This isn't a problem on the source subnet, as it is normal to have two blocks with the same `receiptsRoot` but, it is an issue on the target subnet when we try to execute those transactions. The first transaction would be executed normally but the second transaction would be rejected as it has the same `receiptHash` as the first transaction. We were using a combination of the `receiptsRoot` and the `receiptHash` to identify different transactions.
So, in a nutshell, we need a method to identify these particular transactions uniquely.

## Solution

As a solution, we emit an incrementing `nonce` and the `sourceSubnetId` as part of the `CrossSubnetMessageSent` event from the `ToposCore` contract. This would mean that the receipt `data` would contain an incrementing nonce for a particular subnet for each `sendToken` transaction. Since the receipt's trie keeps a record of the receipt's `data` it would result in a unique `receiptsRoot` for a block. Furthermore, since the `receiptHash` is calculated from the receipt's `data` it would result in a unique `receiptHash`. As a result, this allows us to uniquely identify different valid transactions with similar arguments.

Fixes TP-864


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
